### PR TITLE
Price oracle: OSMO , REGEN CMC not support

### DIFF
--- a/price-oracle/database/database.go
+++ b/price-oracle/database/database.go
@@ -51,6 +51,12 @@ func CnsTokenQuery(db *sqlx.DB) ([]string, error) {
 			if ticker[0:1] == "U" {
 				ticker = ticker[1:]
 			}
+			if ticker == "OSMO" {
+				continue
+			}
+			if ticker == "REGEN" {
+				continue
+			}
 			Whitelists = append(Whitelists, ticker)
 		}
 	}


### PR DESCRIPTION
There is a problem with the query because CMC does not support regen and osmo.

It is a way of querying eight tokens at the same time, and if one token is not supported, all seven coins are ignored and cannot get a price.

If you inquire each, the api cost increases by 8 times.

We're going to use this method temporarily. 

I will remove CMC later and add coinecko.