### PR TITLE
Price Oracle: Subscription UpdateInterval Edit

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -24,6 +24,7 @@ jobs:
               --install \
               --namespace emeris \
               --set image=gcr.io/tendermint-dev/emeris-cns-server:${{ github.event.inputs.version }} \
+              --set updateInterval=10s \
               ./helm/emeris-cns-server
 
   api-server:

--- a/helm/emeris-price-oracle-server/values.yaml
+++ b/helm/emeris-price-oracle-server/values.yaml
@@ -21,4 +21,4 @@ databaseConnectionURL: postgres://root@cockroachdb:26257?sslmode=disable
 debug: true
 
 redisUrl: redis-master:6379
-updateInterval: 10s
+updateInterval: 20s


### PR DESCRIPTION
Set the subscription update interval for the dev environment to 20s because it exceeds the maximum number of calls in the subscription plan.