### PR TITLE
rpcwatcher: check for key presence before trying to write on redis

### DIFF
--- a/rpcwatcher/watcher.go
+++ b/rpcwatcher/watcher.go
@@ -474,6 +474,11 @@ func HandleMessage(w *Watcher, data coretypes.ResultEvent) {
 		}
 
 		key := fmt.Sprintf("%s-%s-%s", chainName, recvPacketSourceChannel[0], recvPacketSequence[0])
+		if !w.store.Exists(key) {
+			w.l.Debugw("bypassing key, event not sourced from us", "chain_name", w.Name, "key", key, "event", "ibc_receive")
+			return
+		}
+
 		var ack Ack
 		if err := json.Unmarshal([]byte(packetAck[0]), &ack); err != nil {
 			w.l.Errorw("unable to unmarshal packetAck", "err", err)
@@ -515,6 +520,11 @@ func HandleMessage(w *Watcher, data coretypes.ResultEvent) {
 		}
 
 		key := fmt.Sprintf("%s-%s-%s", c[0].Counterparty, timeoutPacketSourceChannel[0], timeoutPacketSequence[0])
+		if !w.store.Exists(key) {
+			w.l.Debugw("bypassing key, event not sourced from us", "chain_name", w.Name, "key", key, "event", "timeout")
+			return
+		}
+
 		if err := w.store.SetIbcTimeoutUnlock(key, txHash, chainName, height); err != nil {
 			w.l.Errorw("unable to set status as ibc timeout unlock for key", "key", key, "error", err)
 		}
@@ -545,6 +555,11 @@ func HandleMessage(w *Watcher, data coretypes.ResultEvent) {
 		key := fmt.Sprintf("%s-%s-%s", c[0].Counterparty, ackPacketSourceChannel[0], ackPacketSequence[0])
 		_, ok = data.Events["fungible_token_packet.error"]
 		if ok {
+			if !w.store.Exists(key) {
+				w.l.Debugw("bypassing key, event not sourced from us", "chain_name", w.Name, "key", key, "event", "ibc_ack")
+				return
+			}
+
 			if err := w.store.SetIbcAckUnlock(key, txHash, chainName, height); err != nil {
 				w.l.Errorw("unable to set status as ibc ack unlock for key", "key", key, "error", err)
 			}


### PR DESCRIPTION
This commit tries to handle the case where we observe an IBC operation which wasn't initiated by us, effectively handling this case:

```
2021-09-08T16:47:26.925Z	DEBUG	rpcwatcher/watcher.go:290	got message to handle	{"chain name": "osmosis", "key": "osmosis-43DC6A0D631BF2F49FF2622CE0028D106CB1D0C0A912E1766CBC30704A9E7111", "is create lp": false, "is ibc": false, "is ibc recv": true, "is ibc ack": false, "is ibc timeout": false}
2021-09-08T16:47:26.925Z	DEBUG	rpcwatcher/watcher.go:293	is simple ibc transfer	{"is it": false}
2021-09-08T16:47:26.925Z	ERROR	rpcwatcher/watcher.go:491	unable to set status as ibc received for key	{"key": "osmosis-channel-141-54432", "error": "redis: nil"}
```