### PR TITLE
tracelistener: enable account numbers bulk import

### DIFF
--- a/tracelistener/bulk/bulkimport.go
+++ b/tracelistener/bulk/bulkimport.go
@@ -92,7 +92,7 @@ func (i *Importer) Do() error {
 	rm := rootmulti.NewStore(db)
 
 	var keys []types2.StoreKey
-	for _, ci := range []string{"bank", "ibc", "staking", "distribution", "transfer"} { // todo: add liquidity
+	for _, ci := range []string{"bank", "ibc", "staking", "distribution", "transfer", "acc"} { // todo: add liquidity
 		key := types.NewKVStoreKey(ci)
 		keys = append(keys, key)
 		rm.MountStoreWithDB(key, types.StoreTypeIAVL, nil)


### PR DESCRIPTION
This PR enables tracelistener to bulk import account numbers, processed by the `auth` processor.