### PR TITLE
apply CRDs to local-env.sh

### DIFF
--- a/local-env.sh
+++ b/local-env.sh
@@ -147,6 +147,16 @@ EOF
     kubectl create namespace emeris &> /dev/null
     kubectl config set-context kind-$CLUSTER_NAME --namespace=emeris &> /dev/null
 
+    ### Apply CRDs
+    kubectl apply -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/release-0.43/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagerconfigs.yaml
+    kubectl apply -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/release-0.43/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagers.yaml
+    kubectl apply -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/release-0.43/example/prometheus-operator-crd/monitoring.coreos.com_podmonitors.yaml
+    kubectl apply -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/release-0.43/example/prometheus-operator-crd/monitoring.coreos.com_probes.yaml
+    kubectl apply -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/release-0.43/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml
+    kubectl apply -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/release-0.43/example/prometheus-operator-crd/monitoring.coreos.com_prometheusrules.yaml
+    kubectl apply -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/release-0.43/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml
+    kubectl apply -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/release-0.43/example/prometheus-operator-crd/monitoring.coreos.com_thanosrulers.yaml
+
     ### Ensure nginx ingress controller is deployed
     echo -e "${green}\xE2\x9C\x94${reset} Ensure nginx ingress controller is installed and running"
     kubectl apply \


### PR DESCRIPTION
There was an issue where certain containers such as the API server would not get spun up due to missing CRDs.

Including this in the `local-env.sh` file solves the issue.