### PR TITLE
Refactor/price oracle

### DIFF
--- a/price-oracle/database/schema-unittest
+++ b/price-oracle/database/schema-unittest
@@ -18,16 +18,16 @@ INSERT INTO oracle.coingecko VALUES ('LUNAUSDT','12','9351700038');
 INSERT INTO oracle.coingecko VALUES ('ETHUSDT','10','9351700038');
 SELECT * FROM oracle.coingecko;
 
-CREATE TABLE oracle.coinmarketcapsupply (symbol STRING PRIMARY KEY, price FLOAT, supply FLOAT);
-INSERT INTO oracle.coinmarketcapsupply VALUES ('ATOMUSDT','10','113563929433.0');
-INSERT INTO oracle.coinmarketcapsupply VALUES ('LUNAUSDT','10','113563929433.0');
-INSERT INTO oracle.coinmarketcapsupply VALUES ('ETHUSDT','10','113563929433.0');
+CREATE TABLE oracle.coinmarketcapsupply (symbol STRING PRIMARY KEY, supply FLOAT);
+INSERT INTO oracle.coinmarketcapsupply VALUES ('ATOMUSDT','113563929433.0');
+INSERT INTO oracle.coinmarketcapsupply VALUES ('LUNAUSDT','113563929433.0');
+INSERT INTO oracle.coinmarketcapsupply VALUES ('ETHUSDT','113563929433.0');
 SELECT * FROM oracle.coinmarketcapsupply;
 
-CREATE TABLE oracle.coingeckosupply (symbol STRING PRIMARY KEY,price FLOAT, supply FLOAT);
-INSERT INTO oracle.coingeckosupply VALUES ('ATOMUSDT','10','113563929433.0');
-INSERT INTO oracle.coingeckosupply VALUES ('LUNAUSDT','10','113563929433.0');
-INSERT INTO oracle.coingeckosupply VALUES ('ETHUSDT','10','113563929433.0');
+CREATE TABLE oracle.coingeckosupply (symbol STRING PRIMARY KEY, supply FLOAT);
+INSERT INTO oracle.coingeckosupply VALUES ('ATOMUSDT','113563929433.0');
+INSERT INTO oracle.coingeckosupply VALUES ('LUNAUSDT','113563929433.0');
+INSERT INTO oracle.coingeckosupply VALUES ('ETHUSDT','113563929433.0');
 SELECT * FROM oracle.coingeckosupply;
 
 CREATE TABLE oracle.fixer (symbol STRING PRIMARY KEY, price FLOAT, updatedat INT);


### PR DESCRIPTION
## Only 1 review required!!

Very small change. 
table `oracle.coinmarketcapsupply` and `oracle.coingeakosupply` was updated by removing the `price` column.
file updated : https://github.com/allinbits/demeris-backend/pull/231/files#diff-a85dd4a776d166c66e66ed989c78c8674bc063c0e5c32b0a2945ce0883ed475d Other changes are normie (making a float value explicit).

So schema-unittest file is also updated.