### PR TITLE
Fix logic of /status test

### DIFF
--- a/tests/chains/chain_status_test.go
+++ b/tests/chains/chain_status_test.go
@@ -37,12 +37,16 @@ func TestChainStatus(t *testing.T) {
 			require.NoError(t, err)
 
 			// assert
-			require.Equal(t, http.StatusOK, resp.StatusCode, fmt.Sprintf("Chain %s HTTP code %d", ch.Name, resp.StatusCode))
+			if !ch.Enabled {
+				require.Equal(t, http.StatusBadRequest, resp.StatusCode, fmt.Sprintf("Chain %s HTTP code %d", ch.Name, resp.StatusCode))
+			} else {
+				require.Equal(t, http.StatusOK, resp.StatusCode, fmt.Sprintf("Chain %s HTTP code %d", ch.Name, resp.StatusCode))
 
-			var values map[string]interface{}
-			utils.RespBodyToMap(resp.Body, &values, t)
+				var values map[string]interface{}
+				utils.RespBodyToMap(resp.Body, &values, t)
 
-			require.Equal(t, ch.Enabled, values[onlineKey].(bool), fmt.Sprintf("Chain %s Online %t", ch.Name, values[onlineKey].(bool)))
+				require.Equal(t, true, values[onlineKey].(bool), fmt.Sprintf("Chain %s Online %t", ch.Name, values[onlineKey].(bool)))
+			}
 		})
 	}
 }


### PR DESCRIPTION
Fixes `/status` test logic, to be compatible with [endpoint logic](https://github.com/allinbits/demeris-api-server/blob/main/api/chains/chains.go#L613)
Status test passes for DEV