### PR TITLE
fix: wrong helm paths in local-env.sh

### DIFF
--- a/local-env.sh
+++ b/local-env.sh
@@ -312,7 +312,7 @@ EOF
         --kube-context kind-$CLUSTER_NAME \
         --namespace emeris \
         --set imagePullPolicy=Never \
-        .cns-server/helm/cns-server \
+        .cns-server/helm \
         &> /dev/null
 
     echo -e "${green}\xE2\x9C\x94${reset} Deploying emeris/admin-ui"
@@ -321,7 +321,7 @@ EOF
         --kube-context kind-$CLUSTER_NAME \
         --namespace emeris \
         --set imagePullPolicy=Never \
-        .cns-server/helm/admin-ui \
+        .cns-server/helm \
         &> /dev/null
 
     ### Ensure api-server image


### PR DESCRIPTION
cns-server and admin-ui were not executed since the helm path was wrong

**note:**
there's still a problem with price-oracle: it's complaining that a `fixerKey` is missing, I'm not sure how to address this