### PR TITLE
tests: disable parallelism for chains tests

### DIFF
--- a/tests/chains/account_balance_test.go
+++ b/tests/chains/account_balance_test.go
@@ -16,8 +16,6 @@ const (
 )
 
 func (suite *testCtx) TestGetBalanceOfAnyAccount() {
-	suite.T().Parallel()
-
 	for _, ch := range suite.clientChains {
 		suite.Run(ch.Name, func() {
 			var cc chainClient.Client

--- a/tests/chains/account_numbers_test.go
+++ b/tests/chains/account_numbers_test.go
@@ -16,8 +16,6 @@ const (
 )
 
 func (suite *testCtx) TestGetAccountNumbers() {
-	suite.T().Parallel()
-
 	for _, ch := range suite.clientChains {
 		suite.Run(ch.Name, func() {
 			var cc chainClient.Client

--- a/tests/chains/annual_provisions_test.go
+++ b/tests/chains/annual_provisions_test.go
@@ -14,8 +14,6 @@ const (
 )
 
 func (suite *testCtx) TestAnnualProvisions() {
-	suite.T().Parallel()
-
 	for _, ch := range suite.Chains {
 		suite.T().Run(ch.Name, func(t *testing.T) {
 

--- a/tests/chains/chain_account_numbers_test.go
+++ b/tests/chains/chain_account_numbers_test.go
@@ -16,8 +16,6 @@ const (
 )
 
 func (suite *testCtx) TestGetChainNumbers() {
-	suite.T().Parallel()
-
 	for _, ch := range suite.clientChains {
 		suite.Run(ch.Name, func() {
 			var cc chainClient.Client

--- a/tests/chains/chain_bech32_test.go
+++ b/tests/chains/chain_bech32_test.go
@@ -13,8 +13,6 @@ import (
 const chainBech32Endpoint = "chain/%s/bech32"
 
 func (suite *testCtx) TestChainBech32() {
-	suite.T().Parallel()
-
 	for _, ch := range suite.Chains {
 		suite.T().Run(ch.Name, func(t *testing.T) {
 			// arrange

--- a/tests/chains/chain_data_test.go
+++ b/tests/chains/chain_data_test.go
@@ -14,8 +14,6 @@ const (
 )
 
 func (suite *testCtx) TestChainData() {
-	suite.T().Parallel()
-
 	for _, ch := range suite.Chains {
 		suite.T().Run(ch.Name, func(t *testing.T) {
 

--- a/tests/chains/chain_feeAddress_test.go
+++ b/tests/chains/chain_feeAddress_test.go
@@ -12,8 +12,6 @@ import (
 const chainFeeAddressEndpoint = "chain/%s/fee/address"
 
 func (suite *testCtx) TestChainFeeAddress() {
-	suite.T().Parallel()
-
 	for _, ch := range suite.Chains {
 		suite.T().Run(ch.Name, func(t *testing.T) {
 			// arrange

--- a/tests/chains/chain_feeToken_test.go
+++ b/tests/chains/chain_feeToken_test.go
@@ -13,8 +13,6 @@ import (
 const chainFeeTokenEndpoint = "chain/%s/fee/token"
 
 func (suite *testCtx) TestChainFeeToken() {
-	suite.T().Parallel()
-
 	for _, ch := range suite.Chains {
 		suite.T().Run(ch.Name, func(t *testing.T) {
 			// arrange

--- a/tests/chains/chain_fee_test.go
+++ b/tests/chains/chain_fee_test.go
@@ -13,8 +13,6 @@ import (
 const chainFeeEndpoint = "chain/%s/fee"
 
 func (suite *testCtx) TestChainFee() {
-	suite.T().Parallel()
-
 	for _, ch := range suite.Chains {
 		suite.T().Run(ch.Name, func(t *testing.T) {
 			// arrange

--- a/tests/chains/chain_status_test.go
+++ b/tests/chains/chain_status_test.go
@@ -14,12 +14,8 @@ const (
 )
 
 func (suite *testCtx) TestChainStatus() {
-	suite.T().Parallel()
-
 	for _, ch := range suite.Chains {
 		suite.T().Run(ch.Name, func(t *testing.T) {
-			t.Parallel()
-
 			// arrange
 			url := suite.Client.BuildUrl(statusEndpoint, ch.Name)
 			// act

--- a/tests/chains/chain_supply_test.go
+++ b/tests/chains/chain_supply_test.go
@@ -16,8 +16,6 @@ const (
 )
 
 func (suite *testCtx) TestChainSupply() {
-	suite.T().Parallel()
-
 	for _, ch := range suite.Chains {
 		suite.T().Run(ch.Name, func(t *testing.T) {
 

--- a/tests/chains/chain_txs_test.go
+++ b/tests/chains/chain_txs_test.go
@@ -21,8 +21,6 @@ const (
 )
 
 func (suite *testCtx) TestTxsEndpoint() {
-	suite.T().Parallel()
-
 	for _, ch := range suite.clientChains {
 		suite.Run(ch.Name, func() {
 			var cc chainClient.Client

--- a/tests/chains/chain_validators_test.go
+++ b/tests/chains/chain_validators_test.go
@@ -21,8 +21,6 @@ func (suite *testCtx) TestChainValidators() {
 		return
 	}
 
-	suite.T().Parallel()
-
 	for _, ch := range suite.Chains {
 		suite.T().Run(ch.Name, func(t *testing.T) {
 			// arrange

--- a/tests/chains/chains_data_test.go
+++ b/tests/chains/chains_data_test.go
@@ -11,8 +11,6 @@ import (
 const chainsEndpoint = "chains"
 
 func (suite *testCtx) TestChainsData() {
-	suite.T().Parallel()
-
 	// arrange
 	url := suite.Client.BuildUrl(chainsEndpoint)
 	// act

--- a/tests/chains/chains_feeAddresses_test.go
+++ b/tests/chains/chains_feeAddresses_test.go
@@ -10,8 +10,6 @@ import (
 const chainsFeeAddressesEndpoint = "chains/fee/addresses"
 
 func (suite *testCtx) TestChainsFeeAddresses() {
-	suite.T().Parallel()
-
 	// arrange
 	url := suite.Client.BuildUrl(chainsFeeAddressesEndpoint)
 	// act

--- a/tests/chains/channel_counterparty_test.go
+++ b/tests/chains/channel_counterparty_test.go
@@ -15,8 +15,6 @@ const (
 )
 
 func (suite *testCtx) TestPrimaryChannelCounterparty() {
-	suite.T().Parallel()
-
 	for _, ch := range suite.Chains {
 		suite.T().Run(ch.Name, func(t *testing.T) {
 			if !ch.Enabled {

--- a/tests/chains/mint_inflation_test.go
+++ b/tests/chains/mint_inflation_test.go
@@ -14,8 +14,6 @@ const (
 )
 
 func (suite *testCtx) TestMintInflation() {
-	suite.T().Parallel()
-
 	for _, ch := range suite.Chains {
 		suite.T().Run(ch.Name, func(t *testing.T) {
 

--- a/tests/chains/mint_params_test.go
+++ b/tests/chains/mint_params_test.go
@@ -15,8 +15,6 @@ const (
 
 func (suite *testCtx) TestMintParams() {
 
-	suite.T().Parallel()
-
 	for _, ch := range suite.Chains {
 		suite.T().Run(ch.Name, func(t *testing.T) {
 

--- a/tests/chains/primary_channels_test.go
+++ b/tests/chains/primary_channels_test.go
@@ -16,8 +16,6 @@ const (
 )
 
 func (suite *testCtx) TestPrimaryChannels() {
-	suite.T().Parallel()
-
 	for _, ch := range suite.Chains {
 		suite.T().Run(ch.Name, func(t *testing.T) {
 			// arrange

--- a/tests/chains/verified_denoms_test.go
+++ b/tests/chains/verified_denoms_test.go
@@ -12,8 +12,6 @@ const (
 )
 
 func (suite *testCtx) TestVerifiedDenoms() {
-	suite.T().Parallel()
-
 	var chainsDenoms cns.DenomList
 	for _, ch := range suite.Chains {
 		if ch.Enabled {


### PR DESCRIPTION
In my local machine tests only work if I disable parallelism. (I run them using `ENV=dev go test -count 1 ./tests/chains`).

I have reasons to believe that the problems originate here: https://github.com/allinbits/demeris-backend/blob/master/chain_client/import_accounts.go#L63 since we're using a global state, but I'm not 100% sure.