### PR TITLE
fix: add missing permission for chain-reset new nodesets

### DIFF
--- a/helm/chain-reset/templates/rbac.yaml
+++ b/helm/chain-reset/templates/rbac.yaml
@@ -12,6 +12,7 @@ rules:
   - nodesets
   - nodesets/scale
   verbs:
+  - create
   - get
   - list
   - patch


### PR DESCRIPTION
This PR adds a missing verb (permission) for creating new nodesets. This happen if chain-resetting a chain that currently doesn't have a nodeset (eg. following the runbooks you deleted it because it was misconfigured).