### PR TITLE
Change denom to xrowan, see demeris-backend#499

### DIFF
--- a/ci/prod/chains/sifchain.json
+++ b/ci/prod/chains/sifchain.json
@@ -17,7 +17,7 @@
     },
     "denoms": [
       {
-        "name": "rowan",
+        "name": "xrowan",
         "display_name": "ROWAN",
         "logo": "https://storage.googleapis.com/emeris/logos/rowan.svg",
         "precision": 18,

--- a/ci/staging/chains/sifchain-1.json
+++ b/ci/staging/chains/sifchain-1.json
@@ -15,7 +15,7 @@
       "relayer_denom": true,
       "minimum_thresh_relayer_balance": 42,
       "gas_price_levels": { "low": 0.5, "average": 1, "high": 2 },
-      "name": "urowan",
+      "name": "xrowan",
       "logo": "https://storage.googleapis.com/emeris/logos/rowan.svg",
       "verified": true,
       "precision": 6,


### PR DESCRIPTION
Fixes Sifchain denoms which were not verified like
https://api.emeris.com/v1/chain/cosmos-hub/denom/verify_trace/dcd1849e20837bc8fb2c252a7ae1d8aa7a1876911ee669e6ce6fdf9fea54083d