### PR TITLE
Revert Sifchain back to rowan

### DIFF
--- a/ci/prod/chains/sifchain.json
+++ b/ci/prod/chains/sifchain.json
@@ -17,7 +17,7 @@
     },
     "denoms": [
       {
-        "name": "xrowan",
+        "name": "rowan",
         "display_name": "ROWAN",
         "logo": "https://storage.googleapis.com/emeris/logos/rowan.svg",
         "precision": 18,

--- a/ci/staging/chains/sifchain-1.json
+++ b/ci/staging/chains/sifchain-1.json
@@ -15,7 +15,7 @@
       "relayer_denom": true,
       "minimum_thresh_relayer_balance": 42,
       "gas_price_levels": { "low": 0.5, "average": 1, "high": 2 },
-      "name": "xrowan",
+      "name": "rowan",
       "logo": "https://storage.googleapis.com/emeris/logos/rowan.svg",
       "verified": true,
       "precision": 6,


### PR DESCRIPTION
Apparently `rowan` was [the correct value](https://allinbits.slack.com/archives/C02AXJ0K9F1/p1646237281602909?thread_ts=1646218945.049919&cid=C02AXJ0K9F1) after all.
Reverting