### PR TITLE
ci: fix lint action after release of Go 1.18 (not supported yet)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,15 +20,21 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v2
+
+      - name: Setup go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.17
+
       - name: Configure git for private modules
         env:
           GIT_TOKEN: ${{ secrets.TENDERBOT_GIT_TOKEN }}
         run: git config --global url."https://git:${GIT_TOKEN}@github.com".insteadOf "https://github.com"
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@v3.1.0
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
-          version: v1.43
+          version: v1.44
           args: --timeout 10m
           github-token: ${{ secrets.github_token }}


### PR DESCRIPTION
v2 of the github action was downloading Go 1.18, which is not supported by golang-ci yet (https://github.com/golangci/golangci-lint/issues/2649)