### PR TITLE
chore: upgrade Osmosis in staging to v0.7.4

### DIFF
--- a/ci/staging/nodesets/osmosis.yaml
+++ b/ci/staging/nodesets/osmosis.yaml
@@ -75,9 +75,7 @@ spec:
     reconcilePeriod: 5m
   image:
     name: gcr.io/tendermint-dev/osmosis
-    version: v7.0.2
-  #  build:
-  #    repository: https://github.com/osmosis-labs/osmosis
+    version: v7.0.4
   join:
     genesis:
       url: https://storage.googleapis.com/emeris/genesis/osmosis-1.json


### PR DESCRIPTION
fixes a bug we frequently see when nodes are starting: "panic: 717uosmo is smaller than 1737uosmo: insufficient funds" (actual numbers may vary)