### PR TITLE
feat(chain-reset): import only specific modules

### DIFF
--- a/helm/chain-reset.sh
+++ b/helm/chain-reset.sh
@@ -15,6 +15,8 @@ usage()
     echo -e "  -c, --chain \t\t The chain name (e.g. rizon, cosmos-hub)"
     echo -e "  -s, --sdk \t\t The SDK version of the chain (e.g. 0.42, 0.44), defaults to 0.42"
     echo -e "  -e, --env \t\t Environment name, defaults to staging"
+    echo -e "  --erase-tables \t Database tables to be cleared, defaults to all"
+    echo -e "  --import-modules \t Modules to be bulk imported, defaults to all"
     echo -e "  -h, --help \t\t Show this menu\n"
     exit 1
 }
@@ -53,6 +55,16 @@ case $key in
     shift
     shift
     ;;
+    --import-modules)
+    IMPORT_MODULES="$2"
+    shift
+    shift
+    ;;
+    --erase-tables)
+    ERASE_TABLES="$2"
+    shift
+    shift
+    ;;
     -h|--help)
     usage
     shift
@@ -75,10 +87,16 @@ fi
 
 YAML_FILE="${SCRIPT_DIR}/../ci/${ENVIRONMENT}/nodesets/${CHAIN}.yaml"
 
+escape_commas() { echo "${1//,/\\,}"; }
+ERASE_TABLES="$(escape_commas $ERASE_TABLES)"
+IMPORT_MODULES="$(escape_commas $IMPORT_MODULES)"
+
 echo "-- Launcing bulk import job\n"
 helm install "${CHAIN}" \
   --set sdkVersion="${SDK_VERSION}" \
   --set-file nodesetFile="${YAML_FILE}" \
+  --set eraseTables="${ERASE_TABLES}" \
+  --set importModules="${IMPORT_MODULES}" \
   --namespace emeris \
   "${SCRIPT_DIR}/${RESET_DIR}"
 

--- a/helm/chain-reset/templates/02-erase-data.yaml
+++ b/helm/chain-reset/templates/02-erase-data.yaml
@@ -30,5 +30,9 @@ spec:
         - "{{- include "targetChain" . }}"
         - -db
         - postgresql://root@cockroachdb-public:26257/tracelistener?sslmode=disable
+        {{- if .Values.eraseTables }}
+        - -tables
+        - {{ .Values.eraseTables }}
+        {{ end }}
       restartPolicy: Never
   backoffLimit: 0

--- a/helm/chain-reset/templates/03-reimport-data.yaml
+++ b/helm/chain-reset/templates/03-reimport-data.yaml
@@ -27,7 +27,13 @@ spec:
       - name: tracelistener
         image: "{{- if eq .Values.sdkVersion "0.44" }}{{ .Values.traceListener44Image }}{{- else }}{{ .Values.traceListener42Image }}{{ end }}"
         imagePullPolicy: Always
-        args: ["-import", "/home/nonroot/data/application.db"]
+        args: 
+          - "-import"
+          - "/home/nonroot/data/application.db"
+          {{- if .Values.importModules }}
+          - "-import-modules"
+          - {{ .Values.importModules }}
+          {{ end }}
         env:
         - name: TRACELISTENER_DATABASECONNECTIONURL
           value: postgres://root@cockroachdb-public:26257?sslmode=disable


### PR DESCRIPTION
Old behaviour mantained (reset everything):
```
./helm/chain-reset.sh -c bitcanna -s 0.44 -e staging
```

New behaviour (import selected modules):
```
./helm/chain-reset.sh -c bitcanna -s 0.44 -e staging --import-modules ibc --erase-tables channels,connections,clients
```


This PR requires latest changes to resetchain cmd: https://github.com/EmerisHQ/tracelistener/pull/77