### PR TITLE
fix: use a pinned Tracelistener version (1.2.0)

### DIFF
--- a/ci/dev/nodesets/akash.yaml
+++ b/ci/dev/nodesets/akash.yaml
@@ -27,7 +27,7 @@ spec:
             value: akash
           - name: TRACELISTENER_DEBUG
             value: "true"
-        image: gcr.io/tendermint-dev/emeris-tracelistener-v42:main
+        image: gcr.io/tendermint-dev/emeris-tracelistener-v42:1.2.0
         imagePullPolicy: Always
         resources:
           limits:

--- a/ci/dev/nodesets/cosmos-hub.yaml
+++ b/ci/dev/nodesets/cosmos-hub.yaml
@@ -27,7 +27,7 @@ spec:
             value: cosmos-hub
           - name: TRACELISTENER_DEBUG
             value: "true"
-        image: gcr.io/tendermint-dev/emeris-tracelistener-v44:main
+        image: gcr.io/tendermint-dev/emeris-tracelistener-v44:1.2.0
         imagePullPolicy: Always
         resources:
           limits:

--- a/ci/dev/nodesets/crypto-org.yaml
+++ b/ci/dev/nodesets/crypto-org.yaml
@@ -28,7 +28,7 @@ spec:
             value: crypto-org
           - name: TRACELISTENER_DEBUG
             value: "true"
-        image: gcr.io/tendermint-dev/emeris-tracelistener-v44:main
+        image: gcr.io/tendermint-dev/emeris-tracelistener-v44:1.2.0
         imagePullPolicy: Always
         resources:
           limits:

--- a/ci/dev/nodesets/iris.yaml
+++ b/ci/dev/nodesets/iris.yaml
@@ -27,7 +27,7 @@ spec:
             value: iris
           - name: TRACELISTENER_DEBUG
             value: "true"
-        image: gcr.io/tendermint-dev/emeris-tracelistener-v44:main
+        image: gcr.io/tendermint-dev/emeris-tracelistener-v44:1.2.0
         imagePullPolicy: Always
         resources:
           limits:

--- a/ci/dev/nodesets/osmosis.yaml
+++ b/ci/dev/nodesets/osmosis.yaml
@@ -27,7 +27,7 @@ spec:
             value: osmosis
           - name: TRACELISTENER_DEBUG
             value: "true"
-        image: gcr.io/tendermint-dev/emeris-tracelistener-v44:main
+        image: gcr.io/tendermint-dev/emeris-tracelistener-v44:1.2.0
         imagePullPolicy: Always
         resources:
           limits:

--- a/ci/dev/nodesets/terra.yaml
+++ b/ci/dev/nodesets/terra.yaml
@@ -28,7 +28,7 @@ spec:
             value: terra
           - name: TRACELISTENER_DEBUG
             value: "true"
-        image: gcr.io/tendermint-dev/emeris-tracelistener-v44:main
+        image: gcr.io/tendermint-dev/emeris-tracelistener-v44:1.2.0
         imagePullPolicy: Always
         resources:
           limits:

--- a/ci/staging/nodesets/akash.yaml
+++ b/ci/staging/nodesets/akash.yaml
@@ -50,7 +50,7 @@ spec:
             value: akash
           - name: TRACELISTENER_DEBUG
             value: "true"
-        image: gcr.io/tendermint-dev/emeris-tracelistener-v42:main
+        image: gcr.io/tendermint-dev/emeris-tracelistener-v42:1.2.0
         imagePullPolicy: Always
         resources:
           limits:

--- a/ci/staging/nodesets/bitcanna.yaml
+++ b/ci/staging/nodesets/bitcanna.yaml
@@ -50,7 +50,7 @@ spec:
             value: bitcanna
           - name: TRACELISTENER_DEBUG
             value: "true"
-        image: gcr.io/tendermint-dev/emeris-tracelistener-v44:main
+        image: gcr.io/tendermint-dev/emeris-tracelistener-v44:1.2.0
         imagePullPolicy: Always
         resources:
           limits:

--- a/ci/staging/nodesets/bitsong.yaml
+++ b/ci/staging/nodesets/bitsong.yaml
@@ -50,7 +50,7 @@ spec:
             value: bitsong
           - name: TRACELISTENER_DEBUG
             value: "true"
-        image: gcr.io/tendermint-dev/emeris-tracelistener-v44:main
+        image: gcr.io/tendermint-dev/emeris-tracelistener-v44:1.2.0
         imagePullPolicy: Always
         resources:
           limits:

--- a/ci/staging/nodesets/cheqd.yaml
+++ b/ci/staging/nodesets/cheqd.yaml
@@ -50,7 +50,7 @@ spec:
             value: cheqd
           - name: TRACELISTENER_DEBUG
             value: "true"
-        image: gcr.io/tendermint-dev/emeris-tracelistener-v44:main
+        image: gcr.io/tendermint-dev/emeris-tracelistener-v44:1.2.0
         imagePullPolicy: Always
         resources:
           limits:

--- a/ci/staging/nodesets/chihuahua.yaml
+++ b/ci/staging/nodesets/chihuahua.yaml
@@ -50,7 +50,7 @@ spec:
             value: chihuahua
           - name: TRACELISTENER_DEBUG
             value: "true"
-        image: gcr.io/tendermint-dev/emeris-tracelistener-v44:main
+        image: gcr.io/tendermint-dev/emeris-tracelistener-v44:1.2.0
         imagePullPolicy: Always
         resources:
           limits:

--- a/ci/staging/nodesets/comdex.yaml
+++ b/ci/staging/nodesets/comdex.yaml
@@ -50,7 +50,7 @@ spec:
             value: comdex
           - name: TRACELISTENER_DEBUG
             value: "true"
-        image: gcr.io/tendermint-dev/emeris-tracelistener-v44:main
+        image: gcr.io/tendermint-dev/emeris-tracelistener-v44:1.2.0
         imagePullPolicy: Always
         resources:
           limits:

--- a/ci/staging/nodesets/cosmos-hub.yaml
+++ b/ci/staging/nodesets/cosmos-hub.yaml
@@ -50,7 +50,7 @@ spec:
             value: cosmos-hub
           - name: TRACELISTENER_DEBUG
             value: "true"
-        image: gcr.io/tendermint-dev/emeris-tracelistener-v44:main
+        image: gcr.io/tendermint-dev/emeris-tracelistener-v44:1.2.0
         imagePullPolicy: Always
         resources:
           limits:

--- a/ci/staging/nodesets/crypto-org.yaml
+++ b/ci/staging/nodesets/crypto-org.yaml
@@ -50,7 +50,7 @@ spec:
             value: crypto-org
           - name: TRACELISTENER_DEBUG
             value: "true"
-        image: gcr.io/tendermint-dev/emeris-tracelistener-v44:main
+        image: gcr.io/tendermint-dev/emeris-tracelistener-v44:1.2.0
         imagePullPolicy: Always
         resources:
           limits:

--- a/ci/staging/nodesets/desmos.yaml
+++ b/ci/staging/nodesets/desmos.yaml
@@ -50,7 +50,7 @@ spec:
             value: desmos
           - name: TRACELISTENER_DEBUG
             value: "true"
-        image: gcr.io/tendermint-dev/emeris-tracelistener-v44:main
+        image: gcr.io/tendermint-dev/emeris-tracelistener-v44:1.2.0
         imagePullPolicy: Always
         resources:
           limits:

--- a/ci/staging/nodesets/emoney.yaml
+++ b/ci/staging/nodesets/emoney.yaml
@@ -50,7 +50,7 @@ spec:
             value: emoney
           - name: TRACELISTENER_DEBUG
             value: "true"
-        image: gcr.io/tendermint-dev/emeris-tracelistener-v42:main
+        image: gcr.io/tendermint-dev/emeris-tracelistener-v42:1.2.0
         imagePullPolicy: Always
         resources:
           limits:

--- a/ci/staging/nodesets/ixo.yaml
+++ b/ci/staging/nodesets/ixo.yaml
@@ -50,7 +50,7 @@ spec:
             value: ixo
           - name: TRACELISTENER_DEBUG
             value: "true"
-        image: gcr.io/tendermint-dev/emeris-tracelistener-v42:main
+        image: gcr.io/tendermint-dev/emeris-tracelistener-v42:1.2.0
         imagePullPolicy: Always
         resources:
           limits:

--- a/ci/staging/nodesets/juno.yaml
+++ b/ci/staging/nodesets/juno.yaml
@@ -50,7 +50,7 @@ spec:
             value: juno
           - name: TRACELISTENER_DEBUG
             value: "true"
-        image: gcr.io/tendermint-dev/emeris-tracelistener-v44:main
+        image: gcr.io/tendermint-dev/emeris-tracelistener-v44:1.2.0
         imagePullPolicy: Always
         resources:
           limits:

--- a/ci/staging/nodesets/ki.yaml
+++ b/ci/staging/nodesets/ki.yaml
@@ -50,7 +50,7 @@ spec:
             value: ki
           - name: TRACELISTENER_DEBUG
             value: "true"
-        image: gcr.io/tendermint-dev/emeris-tracelistener-v42:main
+        image: gcr.io/tendermint-dev/emeris-tracelistener-v42:1.2.0
         imagePullPolicy: Always
         resources:
           limits:

--- a/ci/staging/nodesets/likecoin.yaml
+++ b/ci/staging/nodesets/likecoin.yaml
@@ -50,7 +50,7 @@ spec:
             value: likecoin
           - name: TRACELISTENER_DEBUG
             value: "true"
-        image: gcr.io/tendermint-dev/emeris-tracelistener-v42:main
+        image: gcr.io/tendermint-dev/emeris-tracelistener-v42:1.2.0
         imagePullPolicy: Always
         resources:
           limits:

--- a/ci/staging/nodesets/lum.yaml
+++ b/ci/staging/nodesets/lum.yaml
@@ -50,7 +50,7 @@ spec:
             value: lum
           - name: TRACELISTENER_DEBUG
             value: "true"
-        image: gcr.io/tendermint-dev/emeris-tracelistener-v44:main
+        image: gcr.io/tendermint-dev/emeris-tracelistener-v44:1.2.0
         imagePullPolicy: Always
         resources:
           limits:

--- a/ci/staging/nodesets/microtick.yaml
+++ b/ci/staging/nodesets/microtick.yaml
@@ -50,7 +50,7 @@ spec:
             value: microtick
           - name: TRACELISTENER_DEBUG
             value: "true"
-        image: gcr.io/tendermint-dev/emeris-tracelistener-v42:main
+        image: gcr.io/tendermint-dev/emeris-tracelistener-v42:1.2.0
         imagePullPolicy: Always
         resources:
           limits:

--- a/ci/staging/nodesets/osmosis.yaml
+++ b/ci/staging/nodesets/osmosis.yaml
@@ -63,7 +63,7 @@ spec:
             value: osmosis
           - name: TRACELISTENER_DEBUG
             value: "true"
-        image: gcr.io/tendermint-dev/emeris-tracelistener-v44:main
+        image: gcr.io/tendermint-dev/emeris-tracelistener-v44:1.2.0
         imagePullPolicy: Always
         resources:
           limits:

--- a/ci/staging/nodesets/persistence.yaml
+++ b/ci/staging/nodesets/persistence.yaml
@@ -50,7 +50,7 @@ spec:
             value: persistence
           - name: TRACELISTENER_DEBUG
             value: "true"
-        image: gcr.io/tendermint-dev/emeris-tracelistener-v44:main
+        image: gcr.io/tendermint-dev/emeris-tracelistener-v44:1.2.0
         imagePullPolicy: Always
         resources:
           limits:

--- a/ci/staging/nodesets/regen.yaml
+++ b/ci/staging/nodesets/regen.yaml
@@ -50,7 +50,7 @@ spec:
             value: regen
           - name: TRACELISTENER_DEBUG
             value: "true"
-        image: gcr.io/tendermint-dev/emeris-tracelistener-v44:main
+        image: gcr.io/tendermint-dev/emeris-tracelistener-v44:1.2.0
         imagePullPolicy: Always
         resources:
           limits:

--- a/ci/staging/nodesets/rizon.yaml
+++ b/ci/staging/nodesets/rizon.yaml
@@ -50,7 +50,7 @@ spec:
             value: rizon
           - name: TRACELISTENER_DEBUG
             value: "true"
-        image: gcr.io/tendermint-dev/emeris-tracelistener-v44:main
+        image: gcr.io/tendermint-dev/emeris-tracelistener-v44:1.2.0
         imagePullPolicy: Always
         resources:
           limits:

--- a/ci/staging/nodesets/sentinel.yaml
+++ b/ci/staging/nodesets/sentinel.yaml
@@ -50,7 +50,7 @@ spec:
             value: sentinel
           - name: TRACELISTENER_DEBUG
             value: "true"
-        image: gcr.io/tendermint-dev/emeris-tracelistener-v42:main
+        image: gcr.io/tendermint-dev/emeris-tracelistener-v42:1.2.0
         imagePullPolicy: Always
         resources:
           limits:

--- a/ci/staging/nodesets/sifchain.yaml
+++ b/ci/staging/nodesets/sifchain.yaml
@@ -50,7 +50,7 @@ spec:
             value: sifchain
           - name: TRACELISTENER_DEBUG
             value: "true"
-        image: gcr.io/tendermint-dev/emeris-tracelistener-v44:main
+        image: gcr.io/tendermint-dev/emeris-tracelistener-v44:1.2.0
         imagePullPolicy: Always
         resources:
           limits:

--- a/ci/staging/nodesets/sommelier.yaml
+++ b/ci/staging/nodesets/sommelier.yaml
@@ -50,7 +50,7 @@ spec:
             value: sommelier
           - name: TRACELISTENER_DEBUG
             value: "true"
-        image: gcr.io/tendermint-dev/emeris-tracelistener-v44:main
+        image: gcr.io/tendermint-dev/emeris-tracelistener-v44:1.2.0
         imagePullPolicy: Always
         resources:
           limits:

--- a/ci/staging/nodesets/stargaze.yaml
+++ b/ci/staging/nodesets/stargaze.yaml
@@ -50,7 +50,7 @@ spec:
             value: stargaze
           - name: TRACELISTENER_DEBUG
             value: "true"
-        image: gcr.io/tendermint-dev/emeris-tracelistener-v44:main
+        image: gcr.io/tendermint-dev/emeris-tracelistener-v44:1.2.0
         imagePullPolicy: Always
         resources:
           limits:

--- a/ci/staging/nodesets/starname.yaml
+++ b/ci/staging/nodesets/starname.yaml
@@ -50,7 +50,7 @@ spec:
             value: starname
           - name: TRACELISTENER_DEBUG
             value: "true"
-        image: gcr.io/tendermint-dev/emeris-tracelistener-v42:main
+        image: gcr.io/tendermint-dev/emeris-tracelistener-v42:1.2.0
         imagePullPolicy: Always
         resources:
           limits:

--- a/ci/staging/nodesets/terra.yaml
+++ b/ci/staging/nodesets/terra.yaml
@@ -50,7 +50,7 @@ spec:
             value: terra
           - name: TRACELISTENER_DEBUG
             value: "true"
-        image: gcr.io/tendermint-dev/emeris-tracelistener-v44:main
+        image: gcr.io/tendermint-dev/emeris-tracelistener-v44:1.2.0
         imagePullPolicy: Always
         resources:
           limits:


### PR DESCRIPTION
Pin a tracelistener version to avoid changes being accidentally rolled out to staging and prod (😢)