### PR TITLE
fix: remove default tracelistener version in reset-chain helm chart

### DIFF
--- a/helm/chain-reset/values.yaml
+++ b/helm/chain-reset/values.yaml
@@ -3,7 +3,7 @@ traceListener44Image: gcr.io/tendermint-dev/emeris-tracelistener-v44
 imagePullPolicy: Always
 
 sdkVersion: "0.44"
-traceListenerVersion: "main"
+traceListenerVersion: "NO_VERSION_SPECIFIED"
 
 nodesetFile: /tmp/foo
 enableChain: true


### PR DESCRIPTION
This should avoid running unexpected versions for good I hope.