### PR TITLE
ci: use version as image tag when deploying if possible

### DIFF
--- a/.github/workflows/deploy-image-on-dev.yml
+++ b/.github/workflows/deploy-image-on-dev.yml
@@ -21,6 +21,15 @@ concurrency:
   group: ${{ github.event.client_payload.deploy_type }}
   cancel-in-progress: false
 
+env:
+  repo_name: ${{ github.event.client_payload.repo_name }}
+  branch_name: ${{ github.event.client_payload.branch_name }}
+  service_name: ${{ github.event.client_payload.service_name }}
+  image_name: ${{ github.event.client_payload.image_name }}
+  image_sha: ${{ github.event.client_payload.image_sha }}
+  version: ${{ github.event.client_payload.version }}
+  image_tag: ${{ github.event.client_payload.version || github.event.client_payload.image_sha }}
+
 jobs:
   deploy-service:
     runs-on: self-hosted
@@ -29,20 +38,20 @@ jobs:
         uses: actions/checkout@v2
         with:
           token: ${{ secrets.TENDERBOT_GIT_TOKEN }}
-          repository: "allinbits/${{ github.event.client_payload.repo_name }}"
-          ref: ${{ github.event.client_payload.branch_name }}
+          repository: "allinbits/${{ env.repo_name }}"
+          ref: ${{ env.branch_name }}
 
       - name: Deploy
         uses: WyriHaximus/github-action-helm3@v2
         with:
           kubeconfig: "${{ secrets.KUBECONFIG }}"
           exec: |
-            helm upgrade "${{ github.event.client_payload.service_name }}"  \
+            helm upgrade "${{ env.service_name }}"  \
               --install \
               --namespace emeris \
               --set debug=true \
               --set fixerKey=${{ secrets.FIXER_KEY }} \
-              --set image=gcr.io/tendermint-dev/"${{ github.event.client_payload.image_name }}":"${{ github.event.client_payload.image_sha }}" \
+              --set image=gcr.io/tendermint-dev/"${{ env.image_name }}":"${{ env.image_tag }}" \
               --set daggregationPublicBaseUrl=https://dev.demeris.io/v1/daggregation \
               --set redirectURL=https://develop--emeris-admin.netlify.app/login \
               --set test=true \
@@ -62,7 +71,7 @@ jobs:
           command: apply -n emeris -f ci/dev/ingress.yaml
 
   emit-integration-test:
-    if: ${{ github.event.client_payload.deploy_type == 'deploy_dev' }}
+    if: ${{ env.deploy_type == 'deploy_dev' }}
     runs-on: self-hosted
     needs: deploy-service
     steps:
@@ -72,4 +81,9 @@ jobs:
           token: ${{ secrets.TENDERBOT_GIT_TOKEN }}
           repository: allinbits/demeris-backend
           event-type: integration-test
-          client-payload: '{"env":"dev","service_name":"${{ github.event.client_payload.service_name }}","image_sha":"${{ github.event.client_payload.image_sha }}"}'
+          client-payload: |
+            {
+              "env": "dev",
+              "service_name": "${{ env.service_name }}",
+              "image_tag": "${{ env.image_tag }}"
+            }

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -37,4 +37,9 @@ jobs:
           token: ${{ secrets.TENDERBOT_GIT_TOKEN }}
           repository: allinbits/demeris-backend
           event-type: test-pass
-          client-payload: '{"env":"${{ github.event.client_payload.env }}","service_name":"${{ github.event.client_payload.service_name }}","image_sha":"${{ github.event.client_payload.image_sha }}"}'
+          client-payload: |
+            {
+              "env": "${{ github.event.client_payload.env }}",
+              "service_name": "${{ github.event.client_payload.service_name }}",
+              "image_tag": "${{ github.event.client_payload.image_tag }}"
+            }

--- a/.github/workflows/tag-version.yml
+++ b/.github/workflows/tag-version.yml
@@ -11,7 +11,7 @@ env:
   CHECKOUT_REF: ${{ github.event.client_payload.tag || 'master' }}
   ENV: ${{ github.event.client_payload.env }}
   SERVICE_NAME: ${{ github.event.client_payload.service_name }}
-  IMAGE_SHA: ${{ github.event.client_payload.image_sha }}
+  IMAGE_TAG: ${{ github.event.client_payload.image_tag }}
 
 jobs:
   bump-tag:
@@ -40,7 +40,7 @@ jobs:
       uses: stefanzweifel/git-auto-commit-action@v4
       with:
         file_pattern: envs/*.json
-        commit_message: "chore(${{ env.ENV }}): bump ${{ env.SERVICE_NAME }}:${{ env.IMAGE_SHA }}"
+        commit_message: "chore(${{ env.ENV }}): bump ${{ env.SERVICE_NAME }}:${{ env.IMAGE_TAG }}"
 
     - name: Create and push tag
       uses: anothrNick/github-tag-action@master


### PR DESCRIPTION
This PR uses the image "version" (e.g. `1.2.0`) as the docker image tag, instead of the git commit hash. Also, the name `image_sha` was misleading since Docker images/layers also have a sha identifier.

My goal is to improve "readability" in order to make it easier to check which version is running in the cluster, while still having automatic CD of course.