### PR TITLE
ci: add missing env variable to deploy-image github action

### DIFF
--- a/.github/workflows/deploy-image-on-dev.yml
+++ b/.github/workflows/deploy-image-on-dev.yml
@@ -29,6 +29,7 @@ env:
   image_sha: ${{ github.event.client_payload.image_sha }}
   version: ${{ github.event.client_payload.version }}
   image_tag: ${{ github.event.client_payload.version || github.event.client_payload.image_sha }}
+  deploy_type: ${{ github.event.client_payload.deploy_type }}
 
 jobs:
   deploy-service:


### PR DESCRIPTION
I broke this workflow because an environment variable was missing (I think at least, the error is not so clear).