### PR TITLE
chore: upgrade Tracelistener to v1.3.0

### DIFF
--- a/ci/staging/nodesets/akash.yaml
+++ b/ci/staging/nodesets/akash.yaml
@@ -60,7 +60,7 @@ spec:
             value: akash
           - name: TRACELISTENER_DEBUG
             value: "true"
-        image: gcr.io/tendermint-dev/emeris-tracelistener-v42:1.2.0
+        image: gcr.io/tendermint-dev/emeris-tracelistener-v42:v1.3.0
         imagePullPolicy: Always
         resources:
           limits:

--- a/ci/staging/nodesets/bitcanna.yaml
+++ b/ci/staging/nodesets/bitcanna.yaml
@@ -60,7 +60,7 @@ spec:
             value: bitcanna
           - name: TRACELISTENER_DEBUG
             value: "true"
-        image: gcr.io/tendermint-dev/emeris-tracelistener-v44:1.2.0
+        image: gcr.io/tendermint-dev/emeris-tracelistener-v44:v1.3.0
         imagePullPolicy: Always
         resources:
           limits:

--- a/ci/staging/nodesets/bitsong.yaml
+++ b/ci/staging/nodesets/bitsong.yaml
@@ -60,7 +60,7 @@ spec:
             value: bitsong
           - name: TRACELISTENER_DEBUG
             value: "true"
-        image: gcr.io/tendermint-dev/emeris-tracelistener-v44:1.2.0
+        image: gcr.io/tendermint-dev/emeris-tracelistener-v44:v1.3.0
         imagePullPolicy: Always
         resources:
           limits:

--- a/ci/staging/nodesets/cheqd.yaml
+++ b/ci/staging/nodesets/cheqd.yaml
@@ -60,7 +60,7 @@ spec:
             value: cheqd
           - name: TRACELISTENER_DEBUG
             value: "true"
-        image: gcr.io/tendermint-dev/emeris-tracelistener-v44:1.2.0
+        image: gcr.io/tendermint-dev/emeris-tracelistener-v44:v1.3.0
         imagePullPolicy: Always
         resources:
           limits:

--- a/ci/staging/nodesets/chihuahua.yaml
+++ b/ci/staging/nodesets/chihuahua.yaml
@@ -60,7 +60,7 @@ spec:
             value: chihuahua
           - name: TRACELISTENER_DEBUG
             value: "true"
-        image: gcr.io/tendermint-dev/emeris-tracelistener-v44:1.2.0
+        image: gcr.io/tendermint-dev/emeris-tracelistener-v44:v1.3.0
         imagePullPolicy: Always
         resources:
           limits:

--- a/ci/staging/nodesets/comdex.yaml
+++ b/ci/staging/nodesets/comdex.yaml
@@ -60,7 +60,7 @@ spec:
             value: comdex
           - name: TRACELISTENER_DEBUG
             value: "true"
-        image: gcr.io/tendermint-dev/emeris-tracelistener-v44:1.2.0
+        image: gcr.io/tendermint-dev/emeris-tracelistener-v44:v1.3.0
         imagePullPolicy: Always
         resources:
           limits:

--- a/ci/staging/nodesets/cosmos-hub.yaml
+++ b/ci/staging/nodesets/cosmos-hub.yaml
@@ -60,7 +60,7 @@ spec:
             value: cosmos-hub
           - name: TRACELISTENER_DEBUG
             value: "true"
-        image: gcr.io/tendermint-dev/emeris-tracelistener-v44:1.2.0
+        image: gcr.io/tendermint-dev/emeris-tracelistener-v44:v1.3.0
         imagePullPolicy: Always
         resources:
           limits:

--- a/ci/staging/nodesets/crypto-org.yaml
+++ b/ci/staging/nodesets/crypto-org.yaml
@@ -60,7 +60,7 @@ spec:
             value: crypto-org
           - name: TRACELISTENER_DEBUG
             value: "true"
-        image: gcr.io/tendermint-dev/emeris-tracelistener-v44:1.2.0
+        image: gcr.io/tendermint-dev/emeris-tracelistener-v44:v1.3.0
         imagePullPolicy: Always
         resources:
           limits:
@@ -90,7 +90,7 @@ spec:
         port: 26656
   moniker: emeris
   persistence:
-    size: 1000Gi
+    size: 1052Gi
     autoResize:
       enabled: true
   replicas: 2

--- a/ci/staging/nodesets/desmos.yaml
+++ b/ci/staging/nodesets/desmos.yaml
@@ -60,7 +60,7 @@ spec:
             value: desmos
           - name: TRACELISTENER_DEBUG
             value: "true"
-        image: gcr.io/tendermint-dev/emeris-tracelistener-v44:1.2.0
+        image: gcr.io/tendermint-dev/emeris-tracelistener-v44:v1.3.0
         imagePullPolicy: Always
         resources:
           limits:

--- a/ci/staging/nodesets/emoney.yaml
+++ b/ci/staging/nodesets/emoney.yaml
@@ -60,7 +60,7 @@ spec:
             value: emoney
           - name: TRACELISTENER_DEBUG
             value: "true"
-        image: gcr.io/tendermint-dev/emeris-tracelistener-v42:1.2.0
+        image: gcr.io/tendermint-dev/emeris-tracelistener-v42:v1.3.0
         imagePullPolicy: Always
         resources:
           limits:

--- a/ci/staging/nodesets/ixo.yaml
+++ b/ci/staging/nodesets/ixo.yaml
@@ -60,7 +60,7 @@ spec:
             value: ixo
           - name: TRACELISTENER_DEBUG
             value: "true"
-        image: gcr.io/tendermint-dev/emeris-tracelistener-v42:1.2.0
+        image: gcr.io/tendermint-dev/emeris-tracelistener-v42:v1.3.0
         imagePullPolicy: Always
         resources:
           limits:

--- a/ci/staging/nodesets/juno.yaml
+++ b/ci/staging/nodesets/juno.yaml
@@ -60,7 +60,7 @@ spec:
             value: juno
           - name: TRACELISTENER_DEBUG
             value: "true"
-        image: gcr.io/tendermint-dev/emeris-tracelistener-v44:1.2.0
+        image: gcr.io/tendermint-dev/emeris-tracelistener-v44:v1.3.0
         imagePullPolicy: Always
         resources:
           limits:

--- a/ci/staging/nodesets/ki.yaml
+++ b/ci/staging/nodesets/ki.yaml
@@ -60,7 +60,7 @@ spec:
             value: ki
           - name: TRACELISTENER_DEBUG
             value: "true"
-        image: gcr.io/tendermint-dev/emeris-tracelistener-v42:1.2.0
+        image: gcr.io/tendermint-dev/emeris-tracelistener-v42:v1.3.0
         imagePullPolicy: Always
         resources:
           limits:

--- a/ci/staging/nodesets/likecoin.yaml
+++ b/ci/staging/nodesets/likecoin.yaml
@@ -60,7 +60,7 @@ spec:
             value: likecoin
           - name: TRACELISTENER_DEBUG
             value: "true"
-        image: gcr.io/tendermint-dev/emeris-tracelistener-v42:1.2.0
+        image: gcr.io/tendermint-dev/emeris-tracelistener-v42:v1.3.0
         imagePullPolicy: Always
         resources:
           limits:

--- a/ci/staging/nodesets/lum.yaml
+++ b/ci/staging/nodesets/lum.yaml
@@ -60,7 +60,7 @@ spec:
             value: lum
           - name: TRACELISTENER_DEBUG
             value: "true"
-        image: gcr.io/tendermint-dev/emeris-tracelistener-v44:1.2.0
+        image: gcr.io/tendermint-dev/emeris-tracelistener-v44:v1.3.0
         imagePullPolicy: Always
         resources:
           limits:

--- a/ci/staging/nodesets/microtick.yaml
+++ b/ci/staging/nodesets/microtick.yaml
@@ -60,7 +60,7 @@ spec:
             value: microtick
           - name: TRACELISTENER_DEBUG
             value: "true"
-        image: gcr.io/tendermint-dev/emeris-tracelistener-v42:1.2.0
+        image: gcr.io/tendermint-dev/emeris-tracelistener-v42:v1.3.0
         imagePullPolicy: Always
         resources:
           limits:

--- a/ci/staging/nodesets/osmosis.yaml
+++ b/ci/staging/nodesets/osmosis.yaml
@@ -72,7 +72,7 @@ spec:
             value: osmosis
           - name: TRACELISTENER_DEBUG
             value: "true"
-        image: gcr.io/tendermint-dev/emeris-tracelistener-v44:1.2.0
+        image: gcr.io/tendermint-dev/emeris-tracelistener-v44:v1.3.0
         imagePullPolicy: Always
         resources:
           limits:

--- a/ci/staging/nodesets/persistence.yaml
+++ b/ci/staging/nodesets/persistence.yaml
@@ -60,7 +60,7 @@ spec:
             value: persistence
           - name: TRACELISTENER_DEBUG
             value: "true"
-        image: gcr.io/tendermint-dev/emeris-tracelistener-v44:1.2.0
+        image: gcr.io/tendermint-dev/emeris-tracelistener-v44:v1.3.0
         imagePullPolicy: Always
         resources:
           limits:

--- a/ci/staging/nodesets/regen.yaml
+++ b/ci/staging/nodesets/regen.yaml
@@ -60,7 +60,7 @@ spec:
             value: regen
           - name: TRACELISTENER_DEBUG
             value: "true"
-        image: gcr.io/tendermint-dev/emeris-tracelistener-v44:1.2.0
+        image: gcr.io/tendermint-dev/emeris-tracelistener-v44:v1.3.0
         imagePullPolicy: Always
         resources:
           limits:

--- a/ci/staging/nodesets/rizon.yaml
+++ b/ci/staging/nodesets/rizon.yaml
@@ -60,7 +60,7 @@ spec:
             value: rizon
           - name: TRACELISTENER_DEBUG
             value: "true"
-        image: gcr.io/tendermint-dev/emeris-tracelistener-v44:1.2.0
+        image: gcr.io/tendermint-dev/emeris-tracelistener-v44:v1.3.0
         imagePullPolicy: Always
         resources:
           limits:

--- a/ci/staging/nodesets/sentinel.yaml
+++ b/ci/staging/nodesets/sentinel.yaml
@@ -60,7 +60,7 @@ spec:
             value: sentinel
           - name: TRACELISTENER_DEBUG
             value: "true"
-        image: gcr.io/tendermint-dev/emeris-tracelistener-v42:1.2.0
+        image: gcr.io/tendermint-dev/emeris-tracelistener-v42:v1.3.0
         imagePullPolicy: Always
         resources:
           limits:

--- a/ci/staging/nodesets/sifchain.yaml
+++ b/ci/staging/nodesets/sifchain.yaml
@@ -60,7 +60,7 @@ spec:
             value: sifchain
           - name: TRACELISTENER_DEBUG
             value: "true"
-        image: gcr.io/tendermint-dev/emeris-tracelistener-v44:1.2.0
+        image: gcr.io/tendermint-dev/emeris-tracelistener-v44:v1.3.0
         imagePullPolicy: Always
         resources:
           limits:

--- a/ci/staging/nodesets/sommelier.yaml
+++ b/ci/staging/nodesets/sommelier.yaml
@@ -60,7 +60,7 @@ spec:
             value: sommelier
           - name: TRACELISTENER_DEBUG
             value: "true"
-        image: gcr.io/tendermint-dev/emeris-tracelistener-v44:1.2.0
+        image: gcr.io/tendermint-dev/emeris-tracelistener-v44:v1.3.0
         imagePullPolicy: Always
         resources:
           limits:

--- a/ci/staging/nodesets/stargaze.yaml
+++ b/ci/staging/nodesets/stargaze.yaml
@@ -60,7 +60,7 @@ spec:
             value: stargaze
           - name: TRACELISTENER_DEBUG
             value: "true"
-        image: gcr.io/tendermint-dev/emeris-tracelistener-v44:1.2.0
+        image: gcr.io/tendermint-dev/emeris-tracelistener-v44:v1.3.0
         imagePullPolicy: Always
         resources:
           limits:

--- a/ci/staging/nodesets/starname.yaml
+++ b/ci/staging/nodesets/starname.yaml
@@ -60,7 +60,7 @@ spec:
             value: starname
           - name: TRACELISTENER_DEBUG
             value: "true"
-        image: gcr.io/tendermint-dev/emeris-tracelistener-v42:1.2.0
+        image: gcr.io/tendermint-dev/emeris-tracelistener-v42:v1.3.0
         imagePullPolicy: Always
         resources:
           limits:

--- a/ci/staging/nodesets/terra.yaml
+++ b/ci/staging/nodesets/terra.yaml
@@ -60,7 +60,7 @@ spec:
             value: terra
           - name: TRACELISTENER_DEBUG
             value: "true"
-        image: gcr.io/tendermint-dev/emeris-tracelistener-v44:1.2.0
+        image: gcr.io/tendermint-dev/emeris-tracelistener-v44:v1.3.0
         imagePullPolicy: Always
         resources:
           limits:


### PR DESCRIPTION
This PR updates the nodeset yamls to match the current tracelistener version v1.3.0.