### PR TITLE
ci: fix deploy action to use correct variable

### DIFF
--- a/.github/workflows/deploy-image-on-dev.yml
+++ b/.github/workflows/deploy-image-on-dev.yml
@@ -29,7 +29,6 @@ env:
   image_sha: ${{ github.event.client_payload.image_sha }}
   version: ${{ github.event.client_payload.version }}
   image_tag: ${{ github.event.client_payload.version || github.event.client_payload.image_sha }}
-  deploy_type: ${{ github.event.client_payload.deploy_type }}
 
 jobs:
   deploy-service:
@@ -72,7 +71,7 @@ jobs:
           command: apply -n emeris -f ci/dev/ingress.yaml
 
   emit-integration-test:
-    if: ${{ env.deploy_type == 'deploy_dev' }}
+    if: ${{ github.event.client_payload.deploy_type == 'deploy_dev' }}
     runs-on: self-hosted
     needs: deploy-service
     steps:


### PR DESCRIPTION
Sorry for the trouble, apparently we cannot use "env" inside a job "if" but I can't find where it's specified in the github docs 😢 

This should revert my change and fix it.