### PR TITLE
chore: upgrade Tracelistener to v1.3.0 on dev

### DIFF
--- a/ci/dev/nodesets/akash.yaml
+++ b/ci/dev/nodesets/akash.yaml
@@ -27,7 +27,7 @@ spec:
             value: akash
           - name: TRACELISTENER_DEBUG
             value: "true"
-        image: gcr.io/tendermint-dev/emeris-tracelistener-v42:1.2.0
+        image: gcr.io/tendermint-dev/emeris-tracelistener-v42:1.3.0
         imagePullPolicy: Always
         resources:
           limits:

--- a/ci/dev/nodesets/cosmos-hub.yaml
+++ b/ci/dev/nodesets/cosmos-hub.yaml
@@ -27,7 +27,7 @@ spec:
             value: cosmos-hub
           - name: TRACELISTENER_DEBUG
             value: "true"
-        image: gcr.io/tendermint-dev/emeris-tracelistener-v44:1.2.0
+        image: gcr.io/tendermint-dev/emeris-tracelistener-v44:1.3.0
         imagePullPolicy: Always
         resources:
           limits:

--- a/ci/dev/nodesets/crypto-org.yaml
+++ b/ci/dev/nodesets/crypto-org.yaml
@@ -28,7 +28,7 @@ spec:
             value: crypto-org
           - name: TRACELISTENER_DEBUG
             value: "true"
-        image: gcr.io/tendermint-dev/emeris-tracelistener-v44:1.2.0
+        image: gcr.io/tendermint-dev/emeris-tracelistener-v44:1.3.0
         imagePullPolicy: Always
         resources:
           limits:

--- a/ci/dev/nodesets/iris.yaml
+++ b/ci/dev/nodesets/iris.yaml
@@ -27,7 +27,7 @@ spec:
             value: iris
           - name: TRACELISTENER_DEBUG
             value: "true"
-        image: gcr.io/tendermint-dev/emeris-tracelistener-v44:1.2.0
+        image: gcr.io/tendermint-dev/emeris-tracelistener-v44:1.3.0
         imagePullPolicy: Always
         resources:
           limits:

--- a/ci/dev/nodesets/osmosis.yaml
+++ b/ci/dev/nodesets/osmosis.yaml
@@ -27,7 +27,7 @@ spec:
             value: osmosis
           - name: TRACELISTENER_DEBUG
             value: "true"
-        image: gcr.io/tendermint-dev/emeris-tracelistener-v44:1.2.0
+        image: gcr.io/tendermint-dev/emeris-tracelistener-v44:1.3.0
         imagePullPolicy: Always
         resources:
           limits:

--- a/ci/dev/nodesets/terra.yaml
+++ b/ci/dev/nodesets/terra.yaml
@@ -28,7 +28,7 @@ spec:
             value: terra
           - name: TRACELISTENER_DEBUG
             value: "true"
-        image: gcr.io/tendermint-dev/emeris-tracelistener-v44:1.2.0
+        image: gcr.io/tendermint-dev/emeris-tracelistener-v44:1.3.0
         imagePullPolicy: Always
         resources:
           limits:


### PR DESCRIPTION
Upgrade Tracelistener version in the dev environment to v1.3.0.