### PR TITLE
ci: fix workflows to use new dev API url

### DIFF
--- a/.github/workflows/create-dev.yml
+++ b/.github/workflows/create-dev.yml
@@ -408,6 +408,6 @@ jobs:
         run: |
           for f in "./ci/dev/chains/"*
           do
-            curl -X POST -d @$f https://dev.demeris.io/v1/cns/add
+            curl -X POST -d @$f https://api.dev.emeris.com/v1/cns/add
           done
 

--- a/.github/workflows/deploy-image-on-dev.yml
+++ b/.github/workflows/deploy-image-on-dev.yml
@@ -52,7 +52,7 @@ jobs:
               --set debug=true \
               --set fixerKey=${{ secrets.FIXER_KEY }} \
               --set image=gcr.io/tendermint-dev/"${{ env.image_name }}":"${{ env.image_tag }}" \
-              --set daggregationPublicBaseUrl=https://dev.demeris.io/v1/daggregation \
+              --set daggregationPublicBaseUrl=https://api.dev.emeris.com/v1/daggregation \
               --set redirectURL=https://develop.emeris-admin.pages.dev/login \
               --set test=true \
               ./helm


### PR DESCRIPTION
We moved our API url so we need to update them in the github actions.