### PR TITLE
test: replace telepresence with more simple port-forward

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,26 +18,10 @@ generate-swagger:
 dev-int-tests:
 	ENV=dev go test -v ./tests/...
 
-staging-int-tests: telepresence
-	ENV=staging $(TELEPRESENCE) connect \
-		--kubeconfig $(KUBECONFIG)
-		--namespace emeris \
-		-- go test -v ./tests/... \
-
-# find or download telepresence
-.PHONY: telepresence
-telepresence: TELEPRESENCE_VERSION?=2.3.7
-telepresence:
-ifeq (, $(wildcard $(CURRENT_DIR)/bin/telepresence))
-	@{ \
-	set -e ;\
-	echo "Installing telepresence to $(CURRENT_DIR)/bin" ;\
-	mkdir -p $(CURRENT_DIR)/bin ;\
-	curl -sfL https://app.getambassador.io/download/tel2/$(UNAME)/amd64/$(TELEPRESENCE_VERSION)/telepresence -o $(CURRENT_DIR)/bin/telepresence ;\
-	chmod a+x $(CURRENT_DIR)/bin/telepresence ;\
-	}
-endif
-TELEPRESENCE=$(CURRENT_DIR)/bin/telepresence
+staging-int-tests:
+	./test_data/client/staging/port-forward.sh
+	ENV=staging go test -v ./tests/...
+	pkill -f "port-forward"
 
 $(OBJS):
 	go build -o build/$@ -ldflags='-X main.Version=${BRANCH}-${COMMIT}' ${EXTRAFLAGS} ${BASEPKG}/cmd/$@

--- a/test_data/client/staging/akash.json
+++ b/test_data/client/staging/akash.json
@@ -1,6 +1,6 @@
 {
     "chain_name": "akash",
-    "rpc": "http://akash.emeris:26657",
+    "rpc": "http://localhost:10001",
     "address": "akash14kn0kk33szpwus9nh8n87fjel8djx0y0kqafwm",
     "key":"akash_test",
     "mnemonic":"crucial able shoot suffer cradle art melt lake crane outside organ mask champion force dilemma rough merit color portion hammer mimic portion mix spin",

--- a/test_data/client/staging/cosmos-hub.json
+++ b/test_data/client/staging/cosmos-hub.json
@@ -1,6 +1,6 @@
 {
     "chain_name": "cosmos-hub",
-    "rpc": "http://cosmos-hub.emeris:26657",
+    "rpc": "http://localhost:10000",
     "address": "cosmos1sjllsnramtg3ewxqwwrwjxfgc4n4ef9u0tvx7u",
     "key":"test_key",
     "mnemonic":"unable grass pipe pear glue forward gold truck victory pause fragile scan mask morning develop floor treat essence vendor solid surprise theme process sign",

--- a/test_data/client/staging/port-forward.sh
+++ b/test_data/client/staging/port-forward.sh
@@ -1,0 +1,7 @@
+#!/bin/bash -e
+# This script setups the port forward for the blockchain RPC endpoints that are
+# required by the tests.
+
+kubectl port-forward svc/cosmos-hub 10000:26657 &
+kubectl port-forward svc/akash      10001:26657 &
+kubectl port-forward svc/terra      10002:26657 &

--- a/test_data/client/staging/terra.json
+++ b/test_data/client/staging/terra.json
@@ -1,6 +1,6 @@
 {
     "chain_name": "terra",
-    "rpc": "http://terra.emeris:26657",
+    "rpc": "http://localhost:10002",
     "address": "terra1kv78eyqqfz4jsdazql3yk9a209m0nq587x367v",
     "key":"terra_test",
     "mnemonic":"age airport attend curtain medal arrow always kitchen gift egg poet satoshi write benefit unlock century output waste quality anchor system liberty photo culture",


### PR DESCRIPTION
I couldn't get telepresence to work no matter how hard I tried. I switched to a simpler port-forward approach which suits us for now (doesn't require to download new binary and it's easier to understand).

Problem is that tons of tests in staging fail 😄 but that's for another PR