### PR TITLE
chore: upgrade Go version to 1.18 in github actions

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17
+          go-version: 1.18
 
       - name: Configure git for private modules
         env:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17
+          go-version: 1.18
 
       - name: Configure git for private modules
         env:
@@ -31,6 +31,6 @@ jobs:
         uses: golangci/golangci-lint-action@v3.1.0
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
-          version: v1.44
+          version: v1.45
           args: --timeout 10m
           github-token: ${{ secrets.github_token }}


### PR DESCRIPTION
The test action currently fails because of a version mismatch between this go.mod and the Go version used in the actions.