### PR TITLE
test: tiny improvements

### DIFF
--- a/test_utils/suite.go
+++ b/test_utils/suite.go
@@ -15,22 +15,24 @@ type BaseTestSuite struct {
 	Client    *HttpClient
 }
 
+var allowedEnvs = []string{"dev", "staging", "prod"}
+
 func (suite *BaseTestSuite) SetupTest() {
 	suite.Env = os.Getenv("ENV")
-	suite.Assert().NotEmpty(suite.Env, "Got nil value for env:", suite.Env)
+	suite.Require().Contains(allowedEnvs, suite.Env, "ENV must be set to one of %v", allowedEnvs)
 
 	emIngress, _, err := LoadIngressInfo(suite.Env)
-	suite.Assert().NoError(err, "err value:", err)
+	suite.Require().NoError(err)
 
 	suite.EmIngress = emIngress
 
 	chains, err := LoadChainsInfo(suite.Env)
-	suite.Assert().NoError(err, "err value:", err)
+	suite.Require().NoError(err)
 
 	suite.Chains = chains
 
 	client, err := NewHttpClient(suite.Env, suite.EmIngress.Protocol, suite.EmIngress.Host, suite.EmIngress.APIServerPath)
-	suite.Assert().NoError(err, "err value:", err)
+	suite.Require().NoError(err)
 
 	suite.Client = client
 }


### PR DESCRIPTION
- use require in favor of assert to ensure the test stops when the
  conditions aren't met.
- improve ENV check with a better error message and a restricted list.