### PR TITLE
fix: remove non present denoms from dev chains

### DIFF
--- a/ci/dev/chains/cosmos-hub.json
+++ b/ci/dev/chains/cosmos-hub.json
@@ -27,20 +27,6 @@
       "fetch_price": true,
       "relayer_denom": true,
       "minimum_thresh_relayer_balance": 42
-    },
-    {
-      "name": "poolCDE5DC97ED362F71427E8270E8C073A7C27F4CDF161EE1CB90DD429DDE297DC9",
-      "display_name": "Gravity 1",
-      "precision": 6,
-      "verified": true,
-      "ticker": "G1",
-      "gas_price_levels": {
-        "low": 0,
-        "average": 0,
-        "high": 0
-      },
-      "fetch_price": false,
-      "relayer_denom": false
     }
   ],
   "demeris_addresses": [

--- a/ci/dev/chains/osmosis.json
+++ b/ci/dev/chains/osmosis.json
@@ -25,22 +25,6 @@
       "fetch_price": true,
       "relayer_denom": true,
       "minimum_thresh_relayer_balance": 60000000
-    },
-    {
-      "name": "uion",
-      "display_name": "ION",
-      "logo": "https://storage.googleapis.com/emeris/logos/ion.svg",
-      "precision": 6,
-      "verified": true,
-      "ticker": "ION",
-      "price_id": "ion",
-      "gas_price_levels": {
-        "low": 0,
-        "average": 0,
-        "high": 0
-      },
-      "fetch_price": true,
-      "relayer_denom": false
     }
   ],
   "demeris_addresses": [


### PR DESCRIPTION
These two denoms are not really present in the dev chains, and are making some integration tests fail.