### PR TITLE
fix: upgrade Osmosis to v10 in staging

### DIFF
--- a/ci/staging/nodesets/osmosis.yaml
+++ b/ci/staging/nodesets/osmosis.yaml
@@ -85,8 +85,8 @@ spec:
             memory: 1Gi
     reconcilePeriod: 5m
   image:
-    name: gcr.io/tendermint-dev/osmosis
-    version: v7.0.4
+    name: osmolabs/osmosis
+    version: 10.0.0
   join:
     genesis:
       url: https://storage.googleapis.com/emeris/genesis/osmosis-1.json
@@ -187,7 +187,7 @@ spec:
         port: 26656
   moniker: emeris
   persistence:
-    size: 400Gi
+    size: 1Ti
     autoResize:
       enabled: true
   replicas: 4


### PR DESCRIPTION
Not sure why the PVC size didn't match the one in the cluster, I reverted to 1Ti.

I also switched to use the official docker image since I don't have permissions for pushing it to our internal registry.